### PR TITLE
Fix heartbeat not running in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,11 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Copy instrumentation and required lib files for heartbeat
+COPY --from=builder --chown=nextjs:nodejs /app/instrumentation.ts ./instrumentation.ts
+COPY --from=builder --chown=nextjs:nodejs /app/lib/heartbeat.ts ./lib/heartbeat.ts
+COPY --from=builder --chown=nextjs:nodejs /app/lib/supabase.ts ./lib/supabase.ts
+
 USER nextjs
 
 # Heroku dynamically assigns PORT


### PR DESCRIPTION
Copy instrumentation.ts and lib files to standalone output in Dockerfile so heartbeat service initializes on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)