### PR TITLE
Fix heartbeat logs not appearing in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,14 +57,9 @@ RUN addgroup --system --gid 1001 nodejs && \
 # Copy public assets
 COPY --from=builder /app/public ./public
 
-# Copy standalone output
+# Copy standalone output (includes compiled instrumentation automatically)
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-# Copy instrumentation and required lib files for heartbeat
-COPY --from=builder --chown=nextjs:nodejs /app/instrumentation.ts ./instrumentation.ts
-COPY --from=builder --chown=nextjs:nodejs /app/lib/heartbeat.ts ./lib/heartbeat.ts
-COPY --from=builder --chown=nextjs:nodejs /app/lib/supabase.ts ./lib/supabase.ts
 
 USER nextjs
 

--- a/lib/heartbeat.ts
+++ b/lib/heartbeat.ts
@@ -16,7 +16,7 @@ async function performHeartbeat() {
     if (error) {
       console.error('[Heartbeat] Database query failed:', error.message);
     } else {
-      console.log(`[Heartbeat] Database connection alive. Store count: ${count}`);
+      console.info(`[Heartbeat] Database connection alive. Store count: ${count}`);
     }
   } catch (error) {
     console.error('[Heartbeat] Unexpected error:', error);
@@ -42,7 +42,7 @@ export async function startHeartbeat() {
   }catch(error){
     console.error('[Heartbeat] Failed to start heartbeat service:', error);
   }finally{
-    console.log('[Heartbeat] Service started');
+    console.info('[Heartbeat] Service started');
     scheduleNextHeartbeat();
   }
 }
@@ -54,6 +54,6 @@ export function stopHeartbeat() {
   if (heartbeatTimer) {
     clearTimeout(heartbeatTimer);
     heartbeatTimer = null;
-    console.log('[Heartbeat] Service stopped');
+    console.info('[Heartbeat] Service stopped');
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -67,7 +67,7 @@ const nextConfig: NextConfig = {
   // Remove console logs in production
   compiler: {
     removeConsole: process.env.NODE_ENV === 'production' ? {
-      exclude: ['error', 'warn'], // Keep console.error and console.warn in production
+      exclude: ['error', 'warn', 'info'], // Keep console.error, console.warn, and console.info in production
     } : false,
   },
 };


### PR DESCRIPTION
Issue: console.log was being stripped by Next.js compiler in production

Changes:
- Use console.info instead of console.log for heartbeat logs
- Add 'info' to removeConsole exclude list in next.config.ts
- Revert unnecessary Dockerfile changes (standalone includes instrumentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)