### PR TITLE
Fix GitHub Actions: use flyctl-actions directly instead of setup-flyctl

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
-
       - name: Deploy to Fly.io
-        run: fly deploy --remote-only
+        uses: superfly/flyctl-actions@1.5
+        with:
+          args: "deploy --remote-only"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
setup-flyctl doesn't reliably add fly to PATH on ubuntu-latest; using superfly/flyctl-actions@1.5 with args handles both install and deploy in a single step.