### PR TITLE
Fix worker crash on Fly: remove --env-file=.env from start:worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "vite": "vite",
     "typecheck": "react-router typegen && tsc --noEmit",
     "dev:worker": "tsx --env-file=.env --watch workers/inventory-buffer.worker.ts",
-    "start:worker": "tsx --env-file=.env workers/inventory-buffer.worker.ts"
+    "start:worker": "tsx workers/inventory-buffer.worker.ts"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
Node.js throws 'node: .env: not found' when --env-file targets a missing file. On Fly, secrets are injected as env vars directly so the flag is unnecessary. dev:worker keeps --env-file for local dev.