### PR TITLE
Fix web process binding to 0.0.0.0 for Fly proxy reachability

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy": "shopify app deploy",
     "config:use": "shopify app config use",
     "env": "shopify app env",
-    "start": "NODE_OPTIONS=--dns-result-order=ipv4first react-router-serve ./build/server/index.js",
+    "start": "HOST=0.0.0.0 NODE_OPTIONS=--dns-result-order=ipv4first react-router-serve ./build/server/index.js",
     "docker-start": "npm run setup && npm run start",
     "setup": "prisma generate && prisma migrate deploy",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",


### PR DESCRIPTION
react-router-serve defaults to localhost when HOST is unset, causing Fly's proxy health check to fail with 'not listening on 0.0.0.0:3000'. Explicitly setting HOST=0.0.0.0 in the start script ensures the server binds to all interfaces so fly-proxy can always reach it.