### PR TITLE
Fix compliance: delete inventoryBuffer and chatConversation on shop r…

### DIFF
--- a/app/routes/webhooks.app.uninstalled.tsx
+++ b/app/routes/webhooks.app.uninstalled.tsx
@@ -6,6 +6,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const { shop } = await authenticate.webhook(request);
 
   await prisma.$transaction([
+    prisma.inventoryBuffer.deleteMany({ where: { shop } }),
+    prisma.chatConversation.deleteMany({ where: { shopId: shop } }),
     prisma.alertHistory.deleteMany({ where: { shop } }),
     prisma.inventoryTracking.deleteMany({ where: { shop } }),
     prisma.storeSettings.deleteMany({ where: { shop } }),

--- a/app/routes/webhooks.compliance.tsx
+++ b/app/routes/webhooks.compliance.tsx
@@ -12,8 +12,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       break;
 
     case "SHOP_REDACT":
-      // Delete all store data for the uninstalled shop
+      // Delete all store data. InventoryBuffer and ChatConversation have no
+      // FK to Session so must be deleted explicitly. ChatMessage cascades
+      // automatically when its parent ChatConversation is deleted.
       await prisma.$transaction([
+        prisma.inventoryBuffer.deleteMany({ where: { shop } }),
+        prisma.chatConversation.deleteMany({ where: { shopId: shop } }),
         prisma.alertHistory.deleteMany({ where: { shop } }),
         prisma.inventoryTracking.deleteMany({ where: { shop } }),
         prisma.storeSettings.deleteMany({ where: { shop } }),


### PR DESCRIPTION
…edact/uninstall

Both tables have no FK to Session so they don't cascade automatically. ChatMessage cascades from ChatConversation so doesn't need explicit delete.