### PR TITLE
Remove http_service health check to stop noisy /api/health polling

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -31,14 +31,6 @@ primary_region = "iad"
     soft_limit = 200
     hard_limit = 250
 
-  # Grace period lets Node.js finish loading before Fly checks the port.
-  # Without this the smoke check fires instantly and warns "not listening".
-  [[http_service.checks]]
-    grace_period = "15s"
-    interval     = "30s"
-    timeout      = "5s"
-    method       = "GET"
-    path         = "/api/health"
 
 # ── Machine sizes per process type ───────────────────────────────────────────
 [[vm]]


### PR DESCRIPTION
The check was added to fix a cosmetic 'not listening' deploy warning. The app works correctly without it and the repeated requests every ~10s clutter the logs unnecessarily.