### PR TITLE
Fix low-contrast text on landing page

### DIFF
--- a/app/routes/_index/styles.module.css
+++ b/app/routes/_index/styles.module.css
@@ -106,7 +106,7 @@
 .heroNote {
   margin: 20px 0 0;
   font-size: 13px;
-  color: #9ca3af;
+  color: #6b7280;
 }
 
 .primaryButton {
@@ -295,7 +295,7 @@
   gap: 20px;
   align-items: center;
   font-size: 13px;
-  color: #9ca3af;
+  color: #6b7280;
 }
 
 .footer a {


### PR DESCRIPTION
heroNote and footer text used #9ca3af (~2.5:1 contrast on white), failing WCAG AA's 4.5:1 minimum. Switched to #6b7280 (~4.8:1).