### PR TITLE
Redirect embedded iframe loads missing shop= but carrying host=

### DIFF
--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -40,7 +40,10 @@ const FEATURES = [
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
 
-  if (url.searchParams.get("shop")) {
+  // Shopify's embedded admin often loads this URL with only `host` (the shop is
+  // encoded inside it) and no `shop` param — especially via admin.shopify.com —
+  // so check both, or the iframe falls through to the public marketing page.
+  if (url.searchParams.get("shop") || url.searchParams.get("host")) {
     throw redirect(`/app?${url.searchParams.toString()}`);
   }
 


### PR DESCRIPTION
Shopify's embedded admin (especially admin.shopify.com) often loads the app URL with only host= and no shop= param, since the shop is encoded inside host. The redirect-to-/app check only looked at shop=, so those loads fell through and rendered the public marketing landing page inside the Shopify admin iframe instead of the actual app.