### PR TITLE
Verify app-proxy signature on back-in-stock subscribe endpoint

### DIFF
--- a/app/routes/api.back-in-stock.tsx
+++ b/app/routes/api.back-in-stock.tsx
@@ -1,5 +1,6 @@
 import type { ActionFunctionArgs } from "react-router";
 import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -51,30 +52,32 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     });
   }
 
+  // Verifies the request was actually proxied by Shopify (checks the signed HMAC query params)
+  // rather than posted directly to this URL by anyone on the internet.
+  const { session } = await authenticate.public.appProxy(request);
+  if (!session) {
+    return json({ error: "Shop not found" }, 404);
+  }
+  const shop = session.shop;
+
   const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
   if (isRateLimited(ip)) return json({ error: "Too many requests. Please try again later." }, 429);
 
-  let body: { shop?: string; productId?: string; productTitle?: string; email?: string; firstName?: string; lastName?: string };
+  let body: { productId?: string; productTitle?: string; email?: string; firstName?: string; lastName?: string };
   try {
     body = await request.json();
   } catch {
     return json({ error: "Invalid JSON" }, 400);
   }
 
-  const { shop, productId, productTitle, email, firstName, lastName } = body;
+  const { productId, productTitle, email, firstName, lastName } = body;
 
-  if (!shop || !productId || !email) {
-    return json({ error: "Missing required fields: shop, productId, email" }, 400);
+  if (!productId || !email) {
+    return json({ error: "Missing required fields: productId, email" }, 400);
   }
 
   if (!EMAIL_RE.test(email)) {
     return json({ error: "Invalid email address" }, 400);
-  }
-
-  // Verify the shop exists in our DB (prevents spam subscriptions for random shops)
-  const session = await prisma.session.findUnique({ where: { shop } });
-  if (!session) {
-    return json({ error: "Shop not found" }, 404);
   }
 
   const trimName = (v?: string) => v?.trim().slice(0, 100) || null;
@@ -86,7 +89,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       create: { shop, productId: BigInt(productId), productTitle: productTitle ?? null, email, firstName: trimName(firstName), lastName: trimName(lastName) },
     });
     return json({ success: true, message: "You'll be notified when this product is back in stock." });
-  } catch {
+  } catch (error) {
+    console.error("[back-in-stock] failed to upsert subscriber:", error);
     return json({ error: "Failed to subscribe. Please try again." }, 500);
   }
 };

--- a/extensions/back-in-stock/blocks/notify-form.liquid
+++ b/extensions/back-in-stock/blocks/notify-form.liquid
@@ -575,14 +575,14 @@
       email: email,
     };
     if (firstName) payload.firstName = firstName;
-    if (lastName) payload.lastName = lastName;
-
+    if (lastName) payload.lastName = lastName
     fetch('/apps/stock-alert/back-in-stock', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     })
-      .then(function (r) { return r.json(); })
+      .then(function (r) {
+        return r.json(); })
       .then(function (data) {
         if (data.success) {
           onSuccess();


### PR DESCRIPTION
The route accepted POSTs from anywhere on the internet, not just Shopify's storefront proxy, since it never checked the signed HMAC query params. Now uses authenticate.public.appProxy to validate the request and derive the shop from the verified session instead of trusting a client-supplied shop field. Also logs upsert failures instead of swallowing them silently.