### PR TITLE
Fix back-in-stock notifications not firing on restock and widget not …

### DIFF
--- a/app/routes/webhooks.inventory.tsx
+++ b/app/routes/webhooks.inventory.tsx
@@ -222,6 +222,19 @@ async function processInventoryUpdate(
       : null;
 
   if (!alertType) {
+    // Even when the merchant alert isn't needed, the DB status may be stale
+    // (e.g. product went out of stock and back without the status flipping in DB).
+    // Always drain waiting BIS subscribers whenever the product is in stock.
+    if (newStatus === "in_stock") {
+      sendBackInStockNotifications(
+        shop,
+        productId,
+        existingTracking.productTitle ?? "Unknown",
+        shop,
+        process.env.SHOPIFY_APP_URL ?? "",
+        { logoUrl: settings.brandLogoUrl, color: settings.brandColor, senderName: settings.brandSenderName },
+      ).catch((err) => console.error("[Webhook] Back-in-stock notifications failed:", err));
+    }
     console.log(`[Webhook] No alert needed — alertType: none`);
     return;
   }

--- a/extensions/back-in-stock/blocks/notify-form.liquid
+++ b/extensions/back-in-stock/blocks/notify-form.liquid
@@ -337,6 +337,18 @@
     } catch (e) {}
   }
 
+  function clearNotified() {
+    try {
+      var s = getNotifiedSet();
+      s.delete(CFG.productId);
+      if (s.size === 0) {
+        localStorage.removeItem(STORAGE_KEY);
+      } else {
+        localStorage.setItem(STORAGE_KEY, Array.from(s).join(','));
+      }
+    } catch (e) {}
+  }
+
   function isAlreadyNotified() {
     return getNotifiedSet().has(CFG.productId);
   }
@@ -398,9 +410,15 @@
 
     function sync() {
       if (isAlreadyNotified()) {
-        form.style.display = 'none';
-        ourBtn.style.display = '';
-        return;
+        if (isSoldOut()) {
+          // Product still sold out — keep showing "You're on the list"
+          form.style.display = 'none';
+          ourBtn.style.display = '';
+          return;
+        }
+        // Product is back in stock — clear subscription state and restore form
+        clearNotified();
+        ourBtn.style.display = 'none';
       }
       if (isSoldOut()) {
         form.style.display = 'none';


### PR DESCRIPTION
…clearing after restock

- Notify waiting BIS subscribers in the inventory webhook even when alertType is null (stale DB status causes previousStatus to stay in_stock, skipping the restock branch entirely — subscribers were stuck in Waiting forever)
- Clear the bis_notified localStorage entry in the storefront widget when the product is back in stock, so the Add to Cart form is restored instead of showing "You're on the list" indefinitely